### PR TITLE
[트러블 슈팅] 마스터 버튼 + 모달 배경 고정

### DIFF
--- a/src/App.styled.ts
+++ b/src/App.styled.ts
@@ -17,20 +17,25 @@ export const Whole = styled.div`
   }
 `;
 
-export const MainContainer = styled.div<{ $modalOpen: boolean }>`
+export const MainContainer = styled.div`
   width: 390px;
-  height: 100%;
+  height: 100vh;
   background-color: ${Colors.Grayscale0};
   display: flex;
   flex-direction: column;
-  overflow-y: ${({ $modalOpen }) => ($modalOpen ? "hidden" : "auto")};
+  position: relative;
   @media (max-width: 1040px) {
     margin: 0 auto;
   }
   @media (max-width: 390px) {
     width: 100%;
   }
-  position: relative;
+`;
+
+// ✅ 여기서 스크롤만 담당
+export const ScrollArea = styled.div<{ $modalOpen: boolean }>`
+  flex: 1;
+  overflow-y: ${({ $modalOpen }) => ($modalOpen ? "hidden" : "auto")};
 `;
 
 export const MasterButton = styled(MasterButtonIcon)`
@@ -39,6 +44,7 @@ export const MasterButton = styled(MasterButtonIcon)`
   right: 20px;
   cursor: pointer;
   z-index: 10;
+  cursor: pointer;
 
   @media (max-width: 390px) {
     right: 20px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,34 +41,31 @@ const App = () => {
   return (
     <S.Whole>
       <WebBackground />
-      <S.MainContainer $modalOpen={isModalOpen}>
-        <Header />
-        {pathname !== "/" &&
-          pathname !== "/products" &&
-          !pathname.startsWith("/products/category/") && <SectionLine />}
-        {isLoading ? (
-          <Loading />
-        ) : (
-          <>
-            <AppRouter />
-            {user?.type === "ADMIN" && pathname === "/" && (
-              <S.MasterButton
-                onClick={() => {
-                  if (!user) {
-                    openModal("login");
-                  } else {
-                    navigate("/writePost");
-                  }
-                }}
-              />
-            )}
+      <S.MainContainer>
+        <S.ScrollArea $modalOpen={isModalOpen} id="main-container">
+          <Header />
+          {pathname !== "/" &&
+            pathname !== "/products" &&
+            !pathname.startsWith("/products/category/") && <SectionLine />}
+          {isLoading ? <Loading /> : <AppRouter />}
+        </S.ScrollArea>
 
-            {openedModal === "login" && <LoginModal />}
-            {openedModal === "confirm" && <ConfirmModal />}
-            {openedModal === "order" && user && <OrderModal />}
-            {openedModal === "success" && <SuccessModal />}
-          </>
+        {user?.type === "ADMIN" && pathname === "/" && (
+          <S.MasterButton
+            onClick={() => {
+              if (!user) {
+                openModal("login");
+              } else {
+                navigate("/writePost");
+              }
+            }}
+          />
         )}
+
+        {openedModal === "login" && <LoginModal />}
+        {openedModal === "confirm" && <ConfirmModal />}
+        {openedModal === "order" && user && <OrderModal />}
+        {openedModal === "success" && <SuccessModal />}
       </S.MainContainer>
     </S.Whole>
   );

--- a/src/components/common/modal/loginModal/LoginModal.stlyed.ts
+++ b/src/components/common/modal/loginModal/LoginModal.stlyed.ts
@@ -13,6 +13,7 @@ export const Container = styled.div`
   border-radius: 20px;
   position: relative;
   position: absolute;
+  top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
 `;


### PR DESCRIPTION
# 🛠️ 트러블슈팅: 마스터 버튼 & 모달 배경 고정 위치 문제  
[관련 이슈 #54 #68 #77]

## 📌 문제 요약

공동구매 플랫폼 메인 화면에서  
- 관리자 전용 버튼(MasterButton)을 **`MainContainer` 내부에 고정**하고,  
- **모달 배경 또한 스크롤과 무관하게 전체 페이지를 덮도록** 만들고자 했으나, 다음과 같은 문제에 부딪힘:

- 버튼은 **`MainContainer` 내부에 있어야 하는 제약**이 있음
- `absolute`를 사용하면 **스크롤 시 버튼이 함께 올라감**
- `fixed`를 사용하면 **뷰포트 기준으로 위치가 고정되어 레이아웃이 어긋남**
- 모달 배경(`Mask`)도 **스크롤 상단에서 열 경우 전체 페이지를 덮지 못하고 짤림**

---

## 🎯 목표

- 버튼은 반드시 `MainContainer` 내부에 있어야 함
- **스크롤 여부와 무관하게**, 항상 **`MainContainer`의 오른쪽 하단에 고정**
- 모달의 배경(Mask)은 **스크롤 위치와 상관없이 항상 전체 MainContainer를 덮도록**
- **모달 본문과 버튼 모두** 내부 고정처럼 보이고, **반응형 환경에서도 안정적**

---

## 🔍 시도했던 방법들

| 시도 | 문제점 |
|------|--------|
| `position: fixed` | 버튼/모달이 브라우저 기준으로 고정 → MainContainer 기준을 벗어남 |
| `absolute` | 스크롤 시 버튼이 따라 움직임, 모달 배경도 짤림 |
| scrollTop 계산 | 구현 복잡도 증가, 모달 위치 정확도 낮고 유지보수 어려움 |

---

## 🔎 참고 사례: 펫프렌즈 모바일 웹

유사한 UI 구조를 가진 **펫프렌즈 모바일 웹**에서  
하단 고정 탭바 및 모달이 스크롤과 무관하게 위치를 유지하는 것을 확인하고,  
개발자도구를 활용해 분석함.

### 구조적 특징

- 전체 배경은 브라우저(`body`) 전체에 적용됨
- 가운데는 `max-width: 430px`의 AppContainer를 `margin: auto`로 가운데 정렬
- 고정 UI(`BottomBar`, `Modal`)는 `position: fixed` + `width: 100%` + `max-width` + `margin: auto`로 구성

> 💡 즉, 실제로는 **브라우저 기준으로 고정시키되**,  
> **폭과 위치를 제한하여 내부에 있는 것처럼 보이게 하는 설계 트릭**

---

## ✅ 해결 전략

펫프렌즈처럼 `fixed`를 쓰는 방식은 사용할 수 없는 구조였기 때문에,  
다음과 같은 방식으로 구조를 재정비함:

- `MainContainer`를 `position: relative`로 설정
- 내부에 스크롤 전용 영역 `ScrollArea`를 분리
- 버튼은 `absolute`로 `MainContainer` 기준 하단에 고정
- 모달의 배경(Mask)은 `MainContainer.scrollHeight`를 기준으로 height 계산
- 모달 본문 위치도 `scrollTop` 기준으로 보정해 화면 가운데 또는 하단에 정렬

---

## 🎉 결과

- **`MasterButton`은 스크롤과 무관하게 MainContainer 하단에 고정됨**
- **모달 배경은 화면이 어느 위치든 MainContainer 전체를 완전히 덮음**
- **모달 본문도 항상 중앙 또는 하단에 정확히 위치**
- **코드 복잡도는 낮추고**, 유지보수성과 확장성 확보 (e.g. 하단바, 모달 재사용 가능)

---

## 🧠 회고 및 인사이트

- `fixed`는 **브라우저 기준**이기 때문에 컨테이너 내부에 고정된 UI를 구현하기에 부적절할 수 있음
- `absolute`를 사용할 경우, **스크롤 영역과 고정 UI를 명확히 분리**하면 내부 고정 효과를 구현할 수 있음
- 모달 배경 또한 **scrollHeight 기반으로 높이를 지정**하고, **scrollTop 기반으로 위치를 조정**하면 짤림 없이 안정적으로 표시 가능
- 펫프렌즈 사례처럼, **UI는 내부처럼 보여도 실제 위치 기준은 브라우저일 수 있다**는 점에서 레이아웃 트릭이 인상적이었음
- 이번 해결을 통해 모달/버튼 등 주요 UI 구성 요소들의 일관된 배치 원칙이 정립되었고, 다른 고정 UI에도 동일 전략을 적용 가능

---

## 🧾 메타

- **이슈 해결일**: 2025.05.27  
- **참고 사례**: [펫프렌즈 모바일 웹](https://www.pet-friends.co.kr)  
- **작성자**: 김진아
